### PR TITLE
Get Credential List from the server during authentication. 

### DIFF
--- a/HowToFIDO.md
+++ b/HowToFIDO.md
@@ -231,10 +231,13 @@ navigator.credentials.create({
     rp: {...},
     user: {...},
     challenge: ...,
-    pubKeyCredParams: {
+    pubKeyCredParams: [{
       type: "public-key",
       alg: -7
-    },
+    }, {
+      type: "public-key",
+      alg: -257
+    }],
     authenticatorSelection: {
       authenticatorAttachment: "platform", // !!!
       userVerification: "required"         // !!!
@@ -252,10 +255,10 @@ navigator.credentials.create({
 > canceling the creation).
 
 Associate the returned public key and credential id with the user
-account. Also, make sure you associate the credential id **with the
-device** the user just authenticated from. For example, store the
-credential id in a cookie (or associate it with a cookie), or store the
-credential id in local storage.
+account on the server. Also, make sure you associate this credential id as `2FACapableFidoCredential` and store all the transports applicable for this credential on the server. Associate a `2FACapableFIDOCredsAvailable` flag **with the
+user account** locally. For example, store the
+`2FACapableFIDOCredsAvailable` flag in a cookie (or associate it with a cookie), or store the
+`2FACapableFIDOCredsAvailable` flag in local storage. **Don't store the actual credential id locally**. Using `2FACapableFIDOCredsAvailable` flag instead of actual credential id helps cross-browser scenarios.
 
 ## 3 Performing FIDO-based Reauthentication
 
@@ -270,26 +273,22 @@ Reauthentication might happen for the following reasons:
     re-confirm control over the user session.
 
 Let’s look at the last case first: when it’s time to re-authenticate for
-a sensitive action, check whether you have a credential id for this user
-*for the purpose of reauthentication*, i.e., the kind of credential id
-obtained from [<span class="underline">opting the user into FIDO-based
-reauthentication</span>](#opting-into-fido-based-reauthentication). Make
-sure it’s associated with the user *and* device - for example, check a
-cookie or read from local storage.
+a sensitive action, check whether you have a `2FACapableFIDOCredsAvailable` flag for this user
+*for the purpose of reauthentication*.
 
-If *no credential id is available*, serve a traditional login challenge
+If *no `2FACapableFIDOCredsAvailable` flag is available*, serve a traditional login challenge
 suitable for reauthentication\[8\], for example:
 
 ![password reauthentication](images/image15.png)
 
-If, however, you *do* discover a credential id for the current session,
-then you can use FIDO-based reauthentication:
+If, however, you *do* have `2FACapableFIDOCredsAvailable` flag for the current session,
+then you can use FIDO-based reauthentication. Fetch all `2FACapableFidoCredential` credentials from the server for this user. Don't fetch non `2FACapableFidoCredential` credentials like U2F credentials:
 
 ![FIDO reauthentication](images/image2.png)
 
 When the user is ready (in the above example, when they click on the
 “Go\!” button), call `navigator.credentials.get()`, again requiring user
-verification and specifying an “internal” transport:
+verification:
 
 ```javascript
 navigator.credentials.get({
@@ -298,9 +297,14 @@ navigator.credentials.get({
     rpId: ...,
     allowCredentials: [{
       type: “public-key”,
-      id: ..., //!!! use the *one* credential id associated with  
-               //!!! this user/device combination.
-      transports: [“internal”]    //!!!
+      id: ...,        // 2FACapableFidoCredential CredentialID_1
+      transports: ... // Transports associated with CredentialID_1
+    }, {
+      type: “public-key”,
+      id: ...,        // 2FACapableFidoCredential CredentialID_2
+      transports: ... // Transports associated with CredentialID_2
+    }, {
+      ...
     }],
     userVerification: “required”, //!!!
   }
@@ -336,21 +340,20 @@ presumably with a different account. In this case, you should also give
 the user the ability to completely remove their account from being
 listed on the sign-in page.
 
-If the user clicks on “Next”, then check whether you have a credential
-id associated with the user and device (for example, check a cookie or
-read from local storage). If no credential id is available, serve a
+If the user clicks on “Next”, then check whether you have `2FACapableFIDOCredsAvailable` flag associated with the user (for example, check a cookie or
+read from local storage). If no `2FACapableFIDOCredsAvailable` flag is available, serve a
 traditional login challenge suitable for reauthentication, for example:
 
 ![Password-based re-sign-in](images/image3.png)
 
-If, however, you *do* find a credential id for the current session, then
-you can use FIDO-based reauthentication:
+If, however, you *do* have `2FACapableFIDOCredsAvailable` flag for the current session,
+then you can use FIDO-based reauthentication. Fetch all `2FACapableFidoCredential` credentials from the server for this user. Don't fetch non `2FACapableFidoCredential` credentials like U2F credentials:
 
 ![FIDO-based re-sign-in](images/image4.png)
 
 When the user is ready (in the above example, when they click on the
 “Go\!” button), call navigator.credentials.get(), again requiring user
-verification and specifying an “internal” transport:
+verification:
 
 ```javascript
 navigator.credentials.get({
@@ -359,9 +362,14 @@ navigator.credentials.get({
     rpId: ...,
     allowCredentials: [{
       type: “public-key”,
-      id: ..., //!!! use the *one* credential id associated with  
-               //!!! this user/device combination.
-      transports: [“internal”]    //!!!
+      id: ...,        // 2FACapableFidoCredential CredentialID_1
+      transports: ... // Transports associated with CredentialID_1
+    }, {
+      type: “public-key”,
+      id: ...,        // 2FACapableFidoCredential CredentialID_2
+      transports: ... // Transports associated with CredentialID_2
+    }, {
+      ...
     }],
     userVerification: “required”, //!!!
   }
@@ -670,10 +678,13 @@ navigator.credentials.create({
     rp: {...},
     user: {...},
     challenge: ...,
-    pubKeyCredParams: {
+    pubKeyCredParams: [{
       type: "public-key",
       alg: -7
-    },
+    }, {
+      type: "public-key",
+      alg: -257
+    }],
     authenticatorSelection: {
       authenticatorAttachment: "platform", //!!!  
       requireResidentKey: true,            //!!!


### PR DESCRIPTION
This came when an RP was adopting how to do FIDO and asking for advice what to do when user is in cross-browser scenario as they are getting feedback that user can't login. 

Issue is that resident credentials don't work the same across platforms as of now. As we are recommending the websites on how to develop FIDO solution, they are getting into issues in cross-browser scenarios.

With "requireResidentKey=false" during create, Windows platform (I think also on Apple), platform creates a resident/discoverable credential which is overwritten if RP asks for same user from different browser and without exclude list. On Android, platform creates a non-discoverable credential which is not overwritten. 

Here is the flow:
1.	In Edge, login to RP with existing mechanisms. I use password + security key as an example.
2.	RP checks for IsUserVerifyingPlatformAuthenticatorAvailable API which returned true. RP then offered to create a credential with requireResidentKey=false and UserVerificationRequirement=required without any excludelist for User1. Windows created a resident credential and returned Cred1. RP stores that Cred1 into Edge cookie store.
3.	User logs out and tries to login again. RP sees the cookies and offers user to login using platform authenticator. User clicks on the link which start webauthn .get() call with only Cred1 in allowlist. Platform finds Cred1 and user logs in. User then logs out. 
4.	User switches browser and uses chrome and tries to login to RP again. 
5.	Although user already has registered this device, browser cookies don’t have any information about it and user is not offered to login with Windows Hello.
6.	User logs in with password + external security key. 
7.	User offered again to re-register Windows Hello which they have already done earlier. RP offered again to create another credential for user1 without any excludelist. Windows again created a resident credential and has overwritten Cred1 with Cred2 for same user. RP stores Cred2 into Chrome cookie store. 
8.	User switches browser again and uses edge again after sometime. RP cookie had Cred1 value and user is offered to login with Windows Hello with Cred1 in allowlist. Authentication failed as Cred1 does not exist anymore. 

RP could have used exclude list while creating the platform credential. However, it results in an error condition in multi-browser scenario and I can understand the recommendation of no-exclude list for platform authenticator registration. 

This document recommends that RP stores the credentialID be stored locally. I don't see a reason why. Effect will be the same if RP gets this info from the server at the time of authentication. The issue of whether RP should even show the option of platform authenticator authentication can be done with a boolean flag stored locally. 

Proposal is to store a flag locally to denote that platform credentials exist on this device and always fetching credentials from the server. 

 